### PR TITLE
reverting back to local uploading instead of ingest in the terraform-script for testing

### DIFF
--- a/tests/integration/terraform-script.py
+++ b/tests/integration/terraform-script.py
@@ -4,7 +4,7 @@ import os
 import json
 
 BASE_URL = os.getenv("API_GATEWAY_URL", "https://1q1x0d7k93.execute-api.us-east-1.amazonaws.com/prod/")
-DEFAULT_UPLOAD_FILE = os.getenv("UPLOAD_FILE_PATH", "")
+DEFAULT_UPLOAD_FILE = os.getenv("UPLOAD_FILE_PATH", r"C:\Users\mdali\Downloads\hugging-face-model_1.0.0_full_1.0.0_full.zip")
 DEFAULT_TEST_MODEL = os.getenv("TEST_MODEL_ID", "MiniMaxAI/MiniMax-M2")
 
 def upload_test_model():


### PR DESCRIPTION
I was just checking if ingest would work for testing (did not work and won't work until we fix issue #107 )

Reverted it back to local uploading so we can test the endpoints included in terraform-script.py